### PR TITLE
Passthru options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-- '5'
+- '4'
+- '6'
+- '8'

--- a/index.js
+++ b/index.js
@@ -9,12 +9,17 @@ module.exports = JSONToCsv
 
 function JSONToCsv (options) {
   options = options || {}
-  return pumpify(JSONStream.parse(), split(), CsvStream(options.csv))
+  return pumpify(
+    JSONStream.parse(options.path),
+    split(),
+    CsvStream(options.csv)
+  )
 }
 
 function split () {
-  return through.obj(function (array, enc, callback) {
-    array.forEach(this.push.bind(this))
+  return through.obj(function (chunk, enc, callback) {
+    if (Array.isArray(chunk)) chunk.forEach(this.push.bind(this))
+    else this.push(chunk)
     callback(null)
   })
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ const through = require('through2')
 
 module.exports = JSONToCsv
 
-function JSONToCsv () {
-  return pumpify(JSONStream.parse(), split(), CsvStream())
+function JSONToCsv (options) {
+  options = options || {}
+  return pumpify(JSONStream.parse(), split(), CsvStream(options.csv))
 }
 
 function split () {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,34 @@ fs.createReadStream('./data.json')
   .pipe(fs.createWriteStream('./data.csv'))
 ```
 
+## Options
+
+You can pass [JSONStream](https://www.npmjs.com/package/JSONStream) and/or [csv-write-stream](https://www.npmjs.com/package/csv-write-stream) options to `json-to-csv-stream`.
+
+```js
+{
+  // JSONStream options
+  path: undefined,
+
+  // csv-write-stream options
+  csv: {
+    separator: ',',
+    newline: '\n',
+    headers: undefined,
+    sendHeaders: true
+  }
+}
+```
+
+Example:
+
+```js
+jsonToCsv({
+  path: 'clients.*',
+  csv: { headers: ['name', 'address'], separator: ';' }
+})
+```
+
 ## License
 
 MIT © [Ben Drucker](http://bendrucker.me)

--- a/test.js
+++ b/test.js
@@ -34,3 +34,18 @@ test('send csv-write-stream options', function (t) {
     t.equal(string, 'baz\r\nbaz1\r\n', 'outputs customized csv stream')
   })
 })
+
+test('send JSONStream options', function (t) {
+  t.plan(1)
+  const data = [
+    {foo: 'bar', bar: { baz: 'hi', biz: 'ok' }},
+    {foo: 'bar1', bar: { baz: 'hi1', biz: 'ok1' }}
+  ]
+  const options = { path: '*.bar' }
+  const csv = toStream(JSON.stringify(data)).pipe(toCsv(options))
+
+  read(csv, function (err, string) {
+    if (err) return t.end(err)
+    t.equal(string, 'baz,biz\nhi,ok\nhi1,ok1\n', 'outputs filtered csv stream')
+  })
+})

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const toStream = require('string-to-stream')
 const read = require('read-all-stream')
 const toCsv = require('./')
 
-test(function (t) {
+test('default behavior', function (t) {
   t.plan(1)
   const data = [{foo: 'bar', bar: 'baz'}, {foo: 'bar1', bar: 'baz1'}]
   const csv = toStream(JSON.stringify(data)).pipe(toCsv())
@@ -13,5 +13,24 @@ test(function (t) {
   read(csv, function (err, string) {
     if (err) return t.end(err)
     t.equal(string, 'foo,bar\nbar,baz\nbar1,baz1\n', 'outputs csv stream')
+  })
+})
+
+test('send csv-write-stream options', function (t) {
+  t.plan(1)
+  const data = [{foo: 'bar', bar: 'baz'}, {foo: 'bar1', bar: 'baz1'}]
+  const options = {
+    csv: {
+      separator: ';',
+      newline: '\r\n',
+      headers: ['bar'],
+      sendHeaders: false
+    }
+  }
+  const csv = toStream(JSON.stringify(data)).pipe(toCsv(options))
+
+  read(csv, function (err, string) {
+    if (err) return t.end(err)
+    t.equal(string, 'baz\r\nbaz1\r\n', 'outputs customized csv stream')
   })
 })


### PR DESCRIPTION
Add options to be passed to `JSONStream` or `csv-write-stream`, allowing to filter keys, change output csv, etc.